### PR TITLE
Fix order of images.

### DIFF
--- a/ch04/listing-4.2.html
+++ b/ch04/listing-4.2.html
@@ -48,7 +48,7 @@
 
       <div>
         <div class="media">
-          <img class="media-image" src="shoes.png">
+          <img class="media-image" src="runner.png">
           <div class="media-body">
             <h4>Strength</h4>
             <p>
@@ -60,7 +60,7 @@
         </div>
 
         <div class="media">
-          <img class="media-image" src="runner.png">
+          <img class="media-image" src="shoes.png">
           <div class="media-body">
             <h4>Cadence</h4>
             <p>


### PR DESCRIPTION
If shoes come before runner, then the large gap in section 4.3 (Unexpected "float catching") does not show up.